### PR TITLE
TestProxy: Better handling of generic signatures in exception message

### DIFF
--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import de.tobiasroeser.lambdatest.Optional;
 import de.tobiasroeser.lambdatest.internal.LoggerFactory;
+import de.tobiasroeser.lambdatest.internal.Util;
 
 /**
  * Utility class for simple mocking of interfaces.
@@ -156,10 +157,6 @@ public class TestProxy {
 		return "public " + typeVariables + returnTypeName + " " + methodName + "(" + argList + ")";
 	}
 
-	private static String decapitalize(String string) {
-		return string == null || string.isEmpty() ? "" : Character.toLowerCase(string.charAt(0)) + string.substring(1);
-	}
-
 	private static String filterLetters(String string) {
 		return string.replaceAll("[^a-zA-Z0-9]","");
 	}
@@ -177,7 +174,7 @@ public class TestProxy {
 			final String argWithPackages = arg.getTypeName();
 			final String className = removeAllPackages(argWithPackages);
 
-			final String argName = filterLetters(decapitalize("x"));
+			final String argName = filterLetters(Util.decapitalize("x"));
 			argsWithClassAndParameterName.add(className + " " + argName + i);
 		}
 		return mkString(argsWithClassAndParameterName," ,");

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -85,15 +85,15 @@ public class TestProxy {
 	 * @param delegates
 	 *            The objects to which method-invocations of the proxy will be
 	 *            delegated to.
-	 * @return The invocation result of the delegated method calls, if found. If
-	 *         no delegate was found, an exception.
+	 * @return The invocation result of the delegated method calls, if found. If no
+	 *         delegate was found, an exception.
 	 *
 	 * @throws UnsupportedOperationException
 	 *             If no delegate method was found.
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T> T proxy(final ClassLoader classLoader, final List<Class<?>> interfaces,
-							  final List<Object> delegates, final List<Option> options) {
+			final List<Object> delegates, final List<Option> options) {
 
 		return (T) Proxy.newProxyInstance(classLoader, interfaces.toArray(new Class<?>[0]), (proxy, method, args) -> {
 			final String methodName = method.getName();
@@ -134,11 +134,11 @@ public class TestProxy {
 				final String methodSignature = methodSignature(method, args);
 				final String interfaceName = method.getDeclaringClass().getSimpleName();
 
-				throw new UnsupportedOperationException(
-						"Unhandled call: proxy=" + proxy + ", method=" + method + ", args="
-						+ mkArgListString(args)
-						+ "\n ==> Add to " + interfaceName + "::  " + methodSignature + "\n"
-				);
+				throw new UnsupportedOperationException(""
+						+ "Unhandled call: proxy=" + proxy + ", method=" + method + ", args=" + mkString(args, ", ")
+						+ "\nTo handle this call in the proxy, add the following to " + interfaceName
+						+ "\n ==> " + methodSignature + "{}"
+						+ "\n");
 			}
 		});
 	}
@@ -151,7 +151,7 @@ public class TestProxy {
 	}
 
 	private static String decapitalize(String string) {
-	    return string == null || string.isEmpty() ? "" : Character.toLowerCase(string.charAt(0)) + string.substring(1);
+		return string == null || string.isEmpty() ? "" : Character.toLowerCase(string.charAt(0)) + string.substring(1);
 	}
 
 	private static String mkArgListString(final Object[] args) {
@@ -160,10 +160,10 @@ public class TestProxy {
 		}
 		final List<Object> argList = Arrays.asList(args);
 		return mkString(map(argList, o -> {
-					final String className = o.getClass().getSimpleName();
-					final String argName = decapitalize(className);
-					return className + " " + argName;
-				}),
+			final String className = o.getClass().getSimpleName();
+			final String argName = decapitalize(className);
+			return className + " " + argName;
+		}),
 				" ,");
 	}
 
@@ -171,12 +171,11 @@ public class TestProxy {
 	 * Compact version of {@link #proxy(ClassLoader, List, List, List)}.
 	 *
 	 * @param classLoaderOrInterfaceOrDelegateOrOption
-	 *            Variable set of parameters used the following way: 1) if
-	 *            instance of {@link Option}, than used as option, 2) if
-	 *            instance of ClassLoader, then used to create the proxy
-	 *            instance, 3) if a class (no interface), used as delegate
-	 *            object, 4) else it will be used as interface to be implemented
-	 *            by the proxy.
+	 *            Variable set of parameters used the following way: 1) if instance
+	 *            of {@link Option}, than used as option, 2) if instance of
+	 *            ClassLoader, then used to create the proxy instance, 3) if a class
+	 *            (no interface), used as delegate object, 4) else it will be used
+	 *            as interface to be implemented by the proxy.
 	 *
 	 * @see #proxy(ClassLoader, List, List, List)
 	 */

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -159,12 +159,12 @@ public class TestProxy {
 			return "";
 		}
 		final List<Object> argList = Arrays.asList(args);
-		return mkString(map(argList, o -> {
+		final List<String> argsWithClassAndParameterName = map(argList, o -> {
 			final String className = o.getClass().getSimpleName();
 			final String argName = decapitalize(className);
 			return className + " " + argName;
-		}),
-				" ,");
+		});
+		return mkString(argsWithClassAndParameterName," ,");
 	}
 
 	/**

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -1,5 +1,10 @@
 package de.tobiasroeser.lambdatest.proxy;
 
+import static de.tobiasroeser.lambdatest.internal.Util.filterType;
+import static de.tobiasroeser.lambdatest.internal.Util.find;
+import static de.tobiasroeser.lambdatest.internal.Util.map;
+import static de.tobiasroeser.lambdatest.internal.Util.mkString;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -9,10 +14,6 @@ import java.util.List;
 
 import de.tobiasroeser.lambdatest.Optional;
 import de.tobiasroeser.lambdatest.internal.LoggerFactory;
-import static de.tobiasroeser.lambdatest.internal.Util.filterType;
-import static de.tobiasroeser.lambdatest.internal.Util.find;
-import static de.tobiasroeser.lambdatest.internal.Util.map;
-import static de.tobiasroeser.lambdatest.internal.Util.mkString;
 
 /**
  * Utility class for simple mocking of interfaces.

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -1,13 +1,14 @@
 package de.tobiasroeser.lambdatest.proxy;
 
-import static de.tobiasroeser.lambdatest.Expect.expectEquals;
-
 import de.tobiasroeser.lambdatest.testng.FreeSpec;
+import static de.tobiasroeser.lambdatest.Expect.expectEquals;
 
 public class ExampleProxyTest extends FreeSpec {
 
 	interface Dependency {
 		String hello();
+
+		int foobar(String s1, int i2);
 	}
 
 	class ServiceWithDependency {
@@ -37,9 +38,7 @@ public class ExampleProxyTest extends FreeSpec {
 		test("A proxy without delegates as mandatory dependencies should fail", () -> {
 			final Dependency dep = TestProxy.proxy(Dependency.class);
 			final ServiceWithDependency service = new ServiceWithDependency(dep);
-			intercept(UnsupportedOperationException.class, () -> {
-				service.usingDependency();
-			});
+			intercept(UnsupportedOperationException.class, "(?s).*public String hello\\(\\).*",() -> service.usingDependency());
 		});
 
 		test("A proxy with delegates as mandatory dependency should succeed", () -> {
@@ -51,6 +50,17 @@ public class ExampleProxyTest extends FreeSpec {
 			});
 			final ServiceWithDependency service = new ServiceWithDependency(dep);
 			expectEquals(service.usingDependency(), "Hello Proxy!");
+		});
+
+		test("A proxy with with missing implementation should print a nice (copy 'n paste -able) method signature", () -> {
+			final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
+				@SuppressWarnings("unused")
+				public String hello() {
+					return "Hello Proxy!";
+				}
+			});
+			intercept(UnsupportedOperationException.class, "(?s).*public int foobar\\(String string ,Integer integer\\).*",
+					() -> dep.foobar("a",1));
 		});
 
 	}

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -11,10 +11,12 @@ import de.tobiasroeser.lambdatest.testng.FreeSpec;
 
 public class ExampleProxyTest extends FreeSpec {
 
-	interface Dependency {
+	interface Dependency<U> {
 		String hello();
 
 		int foobar(String s1, int i2);
+
+		U baz(List<U> arg1);
 
 		String list(List<String> strings);
 
@@ -22,7 +24,7 @@ public class ExampleProxyTest extends FreeSpec {
 
 		<T, S> T generics2(List<S> ts);
 
-		<T, S> T generics3(Map<S,List<T>> ts);
+		<T, S> T generics3(Map<S, List<T>> ts);
 	}
 
 	class ServiceWithDependency {
@@ -81,6 +83,18 @@ public class ExampleProxyTest extends FreeSpec {
 										"(?s).*public int foobar\\(String x0 ,int x1\\).*",
 										() -> dep.foobar("a", 1));
 							});
+					test("case: U baz(List<U> arg1)",
+							() -> {
+								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
+									@SuppressWarnings("unused")
+									public String hello() {
+										return "Hello Proxy!";
+									}
+								});
+								intercept(UnsupportedOperationException.class,
+										"(?s).*public U baz\\(List<U> x0\\).*",
+										() -> dep.baz(new ArrayList()));
+							});
 					test("case: String list(List<String> strings)",
 							() -> {
 								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
@@ -120,17 +134,19 @@ public class ExampleProxyTest extends FreeSpec {
 							});
 
 					test("case: <T, S> T generics3(Map<S,List<T>> ts)",
-											() -> {
-												final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
-													@SuppressWarnings("unused")
-													public String hello() {
-														return "Hello Proxy!";
-													}
-												});
-												intercept(UnsupportedOperationException.class,
-														"(?s).*public <T, S> T generics3\\(Map<S, List<T>> x0\\).*",
-														() -> dep.generics3(new LinkedHashMap<String, List<String>>()));
-											});
+							() -> {
+								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
+									@SuppressWarnings("unused")
+									public String hello() {
+										return "Hello Proxy!";
+									}
+								});
+								intercept(UnsupportedOperationException.class,
+										"(?s).*public <T, S> T generics3\\(Map<S, List<T>> x0\\).*",
+										() -> {
+											dep.generics3(new LinkedHashMap<String, List<String>>());
+										});
+							});
 				});
 	}
 

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -2,6 +2,11 @@ package de.tobiasroeser.lambdatest.proxy;
 
 import static de.tobiasroeser.lambdatest.Expect.expectEquals;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import de.tobiasroeser.lambdatest.testng.FreeSpec;
 
 public class ExampleProxyTest extends FreeSpec {
@@ -10,6 +15,14 @@ public class ExampleProxyTest extends FreeSpec {
 		String hello();
 
 		int foobar(String s1, int i2);
+
+		String list(List<String> strings);
+
+		<T> T generics1(List<T> ts);
+
+		<T, S> T generics2(List<S> ts);
+
+		<T, S> T generics3(Map<S,List<T>> ts);
 	}
 
 	class ServiceWithDependency {
@@ -39,7 +52,8 @@ public class ExampleProxyTest extends FreeSpec {
 		test("A proxy without delegates as mandatory dependencies should fail", () -> {
 			final Dependency dep = TestProxy.proxy(Dependency.class);
 			final ServiceWithDependency service = new ServiceWithDependency(dep);
-			intercept(UnsupportedOperationException.class, "(?s).*public String hello\\(\\).*",() -> service.usingDependency());
+			intercept(UnsupportedOperationException.class, "(?s).*public String hello\\(\\).*",
+					() -> service.usingDependency());
 		});
 
 		test("A proxy with delegates as mandatory dependency should succeed", () -> {
@@ -53,17 +67,71 @@ public class ExampleProxyTest extends FreeSpec {
 			expectEquals(service.usingDependency(), "Hello Proxy!");
 		});
 
-		test("A proxy with with missing implementation should print a nice (copy 'n paste -able) method signature", () -> {
-			final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
-				@SuppressWarnings("unused")
-				public String hello() {
-					return "Hello Proxy!";
-				}
-			});
-			intercept(UnsupportedOperationException.class, "(?s).*public int foobar\\(String string ,Integer integer\\).*",
-					() -> dep.foobar("a",1));
-		});
+		section("A proxy with with missing implementation should print a nice (copy 'n paste -able) method signature",
+				() -> {
+					test("case: int foobar(String s1, int i2)",
+							() -> {
+								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
+									@SuppressWarnings("unused")
+									public String hello() {
+										return "Hello Proxy!";
+									}
+								});
+								intercept(UnsupportedOperationException.class,
+										"(?s).*public int foobar\\(String x0 ,int x1\\).*",
+										() -> dep.foobar("a", 1));
+							});
+					test("case: String list(List<String> strings)",
+							() -> {
+								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
+									@SuppressWarnings("unused")
+									public String hello() {
+										return "Hello Proxy!";
+									}
+								});
+								intercept(UnsupportedOperationException.class,
+										"(?s).*public String list\\(List<String> x0\\).*",
+										() -> dep.list(new ArrayList<>()));
+							});
 
+					test("case: <T> T generics1(List<T> ts)",
+							() -> {
+								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
+									@SuppressWarnings("unused")
+									public String hello() {
+										return "Hello Proxy!";
+									}
+								});
+								intercept(UnsupportedOperationException.class,
+										"(?s).*public <T> T generics1\\(List<T> x0\\).*",
+										() -> dep.generics1(new ArrayList<String>()));
+							});
+					test("case: <T, S> T generics2(List<S> ts)",
+							() -> {
+								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
+									@SuppressWarnings("unused")
+									public String hello() {
+										return "Hello Proxy!";
+									}
+								});
+								intercept(UnsupportedOperationException.class,
+										"(?s).*public <T, S> T generics2\\(List<S> x0\\).*",
+										() -> dep.generics2(new ArrayList<String>()));
+							});
+
+					test("case: <T, S> T generics3(Map<S,List<T>> ts)",
+											() -> {
+												final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
+													@SuppressWarnings("unused")
+													public String hello() {
+														return "Hello Proxy!";
+													}
+												});
+												intercept(UnsupportedOperationException.class,
+														"(?s).*public <T, S> T generics3\\(Map<S, List<T>> x0\\).*",
+														() -> dep.generics3(new LinkedHashMap<String, List<String>>()));
+											});
+				});
 	}
 
 }

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -1,7 +1,8 @@
 package de.tobiasroeser.lambdatest.proxy;
 
-import de.tobiasroeser.lambdatest.testng.FreeSpec;
 import static de.tobiasroeser.lambdatest.Expect.expectEquals;
+
+import de.tobiasroeser.lambdatest.testng.FreeSpec;
 
 public class ExampleProxyTest extends FreeSpec {
 


### PR DESCRIPTION
Added handling of following cases:
```
* case: int foobar(String s1, int i2)
* case: U baz(List<U> arg1)
* case: String list(List<String> strings)
* case: <T> T generics1(List<T> ts)
* case: <T, S> T generics2(List<S> ts)
* case: <T, S> T generics3(Map<S,List<T>> ts)
```
Parameter are numbered with position e.g. foobar(String x0, int x1). 
This could be improved ...