### PR TITLE
TestProxy: Better handling of generic signatures in exception message

### DIFF
--- a/src/main/java/de/tobiasroeser/lambdatest/F2.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/F2.java
@@ -1,0 +1,15 @@
+package de.tobiasroeser.lambdatest;
+
+/**
+ * A function with a parameter and a return value.
+ * 
+ * @param <A>
+ *            The parameter type 1.
+ * @param <B>
+ *            The parameter type 2.
+ * @param <R>
+ *            The return type.
+ */
+public interface F2<A, B, R> {
+	R apply(A a, B b);
+}

--- a/src/main/java/de/tobiasroeser/lambdatest/internal/Util.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/internal/Util.java
@@ -7,6 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import de.tobiasroeser.lambdatest.F1;
+import de.tobiasroeser.lambdatest.F2;
 import de.tobiasroeser.lambdatest.Optional;
 
 /**
@@ -65,6 +66,17 @@ public class Util {
 				: new LinkedList<R>();
 		for (final T t : source) {
 			result.add(convert.apply(t));
+		}
+		return result;
+	}
+
+	public static <R, T> List<R> zipWithIndex(final Iterable<T> source,
+												   final F2<? super Integer, ? super T, ? extends R> convert) {
+		final List<R> result = (source instanceof Collection<?>) ? new ArrayList<>(((Collection<?>) source).size())
+				: new LinkedList<>();
+		int i = 0;
+		for (final T t : source) {
+			result.add(convert.apply(i, t));
 		}
 		return result;
 	}

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -3,7 +3,6 @@ package de.tobiasroeser.lambdatest.proxy;
 import static de.tobiasroeser.lambdatest.internal.Util.decapitalize;
 import static de.tobiasroeser.lambdatest.internal.Util.filterType;
 import static de.tobiasroeser.lambdatest.internal.Util.find;
-import static de.tobiasroeser.lambdatest.internal.Util.map;
 import static de.tobiasroeser.lambdatest.internal.Util.mkString;
 
 import java.lang.reflect.InvocationTargetException;
@@ -12,15 +11,12 @@ import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import de.tobiasroeser.lambdatest.Optional;
 import de.tobiasroeser.lambdatest.internal.LoggerFactory;
-import de.tobiasroeser.lambdatest.internal.Util;
 
 /**
  * Utility class for simple mocking of interfaces.
@@ -160,27 +156,6 @@ public class TestProxy {
 		return "public " + typeVariables + returnTypeName + " " + methodName + "(" + argList + ")";
 	}
 
-	private static String mkArgListStringOld(Class<?>[] types) {
-		if (types == null) {
-			return "";
-		}
-
-		// type count to avoid clashing names
-		final Map<String, Integer> count = new LinkedHashMap<>();
-
-		final List<Class<?>> paramList = Arrays.asList(types);
-		final List<String> args = map(paramList, o -> {
-			final String className = o.getSimpleName();
-			final String argName = decapitalize(className);
-			Integer c = count.get(argName);
-			c = c == null ? 1 : c + 1;
-			count.put(argName, c);
-			return className + " " + argName + c;
-		});
-
-		return mkString(args, ", ");
-	}
-
 	private static String filterLetters(String string) {
 		return string.replaceAll("[^a-zA-Z0-9]","");
 	}
@@ -198,7 +173,7 @@ public class TestProxy {
 			final String argWithPackages = arg.getTypeName();
 			final String className = removeAllPackages(argWithPackages);
 
-			final String argName = filterLetters(Util.decapitalize("x"));
+			final String argName = filterLetters(decapitalize("x"));
 			argsWithClassAndParameterName.add(className + " " + argName + i);
 		}
 		return mkString(argsWithClassAndParameterName," ,");

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -176,11 +176,12 @@ public class TestProxy {
 		for(int i =0; i < parameterTypes.length; i++) {
 			final Type arg = parameterTypes[i];
 			final Class<?> clazz = parameterClasses[i];
-			final String clazzSimpleName = clazz.getSimpleName();
+			boolean isErasedOrObject = Object.class.equals(clazz);
 
+			final String clazzSimpleName = clazz.getSimpleName();
 			final String argWithPackages = arg.getTypeName();
-			boolean isUnboundType = Object.class.equals(clazz);
-			final String className = isUnboundType ? "Object" : removeAllPackages(argWithPackages);
+
+			final String className = isErasedOrObject ? "Object" : removeAllPackages(argWithPackages);
 			final String argName = filterLetters(decapitalize(clazzSimpleName));
 
 			argsWithClassAndParameterName.add(className + " " + argName + i);

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -147,7 +147,7 @@ public class TestProxy {
 	}
 
 	private static String methodSignature(final Method method) {
-		final String argList = mkArgListString(method.getGenericParameterTypes());
+		final String argList = mkArgListString(method);
 		final String methodName = method.getName();
 		final String returnTypeName = removeAllPackages(method.getGenericReturnType().getTypeName());
 		final TypeVariable<Method>[] typeParameters = method.getTypeParameters();
@@ -163,17 +163,26 @@ public class TestProxy {
 	private static String mkTypeVariablesList(TypeVariable<Method>[] typeParameters){
 		return "<" + mkString(Arrays.stream(typeParameters).map(t -> t.getTypeName()).collect(Collectors.toList()),", ") + ">";
 	}
-	private static String mkArgListString(final Type[] args) {
-		if (args == null) {
+	private static String mkArgListString(Method method) {
+
+		final Type[] parameterTypes = method.getGenericParameterTypes();
+		final Class<?>[] parameterClasses = method.getParameterTypes();
+
+		if (parameterTypes == null || parameterClasses == null) {
 			return "";
 		}
-		final List<String> argsWithClassAndParameterName = new LinkedList<>();
-		for(int i =0; i < args.length; i++) {
-			final Type arg = args[i];
-			final String argWithPackages = arg.getTypeName();
-			final String className = removeAllPackages(argWithPackages);
 
-			final String argName = filterLetters(decapitalize("x"));
+		final List<String> argsWithClassAndParameterName = new LinkedList<>();
+		for(int i =0; i < parameterTypes.length; i++) {
+			final Type arg = parameterTypes[i];
+			final Class<?> clazz = parameterClasses[i];
+			final String clazzSimpleName = clazz.getSimpleName();
+
+			final String argWithPackages = arg.getTypeName();
+			boolean isUnboundType = Object.class.equals(clazz);
+			final String className = isUnboundType ? "Object" : removeAllPackages(argWithPackages);
+			final String argName = filterLetters(decapitalize(clazzSimpleName));
+
 			argsWithClassAndParameterName.add(className + " " + argName + i);
 		}
 		return mkString(argsWithClassAndParameterName," ,");

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -143,36 +143,21 @@ public class ExampleProxyTest extends FreeSpec {
 				() -> {
 					test("case: int foobar(String s1, int i2)",
 							() -> {
-								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
-									@SuppressWarnings("unused")
-									public String hello() {
-										return "Hello Proxy!";
-									}
-								});
+								final Dependency dep = TestProxy.proxy(Dependency.class);
 								intercept(UnsupportedOperationException.class,
 										"(?s).*public int foobar\\(String string0 ,int int1\\).*",
 										() -> dep.foobar("a", 1));
 							});
 					test("case: U baz(List<U> arg1)",
 							() -> {
-								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
-									@SuppressWarnings("unused")
-									public String hello() {
-										return "Hello Proxy!";
-									}
-								});
+								final Dependency dep = TestProxy.proxy(Dependency.class);
 								intercept(UnsupportedOperationException.class,
 										"(?s).*public U baz\\(List<U> list0\\).*",
 										() -> dep.baz(new ArrayList()));
 							});
 					test("case: String list(List<String> strings)",
 							() -> {
-								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
-									@SuppressWarnings("unused")
-									public String hello() {
-										return "Hello Proxy!";
-									}
-								});
+								final Dependency dep = TestProxy.proxy(Dependency.class);
 								intercept(UnsupportedOperationException.class,
 										"(?s).*public String list\\(List<String> list0\\).*",
 										() -> dep.list(new ArrayList<>()));
@@ -180,24 +165,14 @@ public class ExampleProxyTest extends FreeSpec {
 
 					test("case: <T> T generics1(List<T> ts)",
 							() -> {
-								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
-									@SuppressWarnings("unused")
-									public String hello() {
-										return "Hello Proxy!";
-									}
-								});
+								final Dependency dep = TestProxy.proxy(Dependency.class);
 								intercept(UnsupportedOperationException.class,
 										"(?s).*public <T> T generics1\\(List<T> list0\\).*",
 										() -> dep.generics1(new ArrayList<String>()));
 							});
 					test("case: <T, S> T generics2(List<S> ts)",
 							() -> {
-								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
-									@SuppressWarnings("unused")
-									public String hello() {
-										return "Hello Proxy!";
-									}
-								});
+								final Dependency dep = TestProxy.proxy(Dependency.class);
 								intercept(UnsupportedOperationException.class,
 										"(?s).*public <T, S> T generics2\\(List<S> list0\\).*",
 										() -> dep.generics2(new ArrayList<String>()));
@@ -205,12 +180,7 @@ public class ExampleProxyTest extends FreeSpec {
 
 					test("case: <T, S> T generics3(Map<S,List<T>> ts)",
 							() -> {
-								final Dependency dep = TestProxy.proxy(Dependency.class, new Object() {
-									@SuppressWarnings("unused")
-									public String hello() {
-										return "Hello Proxy!";
-									}
-								});
+								final Dependency dep = TestProxy.proxy(Dependency.class);
 								intercept(UnsupportedOperationException.class,
 										"(?s).*public <T, S> T generics3\\(Map<S, List<T>> map0\\).*",
 										() -> {

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -119,7 +119,7 @@ public class ExampleProxyTest extends FreeSpec {
 				}
 			});
 			intercept(UnsupportedOperationException.class,
-					"(?s).*\\Qpublic boolean genericArg(T x0)\\E.*",
+					"(?s).*\\Qpublic boolean genericArg(Object object0)\\E.*",
 					() -> dep.genericArg("1"));
 		});
 
@@ -150,7 +150,7 @@ public class ExampleProxyTest extends FreeSpec {
 									}
 								});
 								intercept(UnsupportedOperationException.class,
-										"(?s).*public int foobar\\(String x0 ,int x1\\).*",
+										"(?s).*public int foobar\\(String string0 ,int int1\\).*",
 										() -> dep.foobar("a", 1));
 							});
 					test("case: U baz(List<U> arg1)",
@@ -162,7 +162,7 @@ public class ExampleProxyTest extends FreeSpec {
 									}
 								});
 								intercept(UnsupportedOperationException.class,
-										"(?s).*public U baz\\(List<U> x0\\).*",
+										"(?s).*public U baz\\(List<U> list0\\).*",
 										() -> dep.baz(new ArrayList()));
 							});
 					test("case: String list(List<String> strings)",
@@ -174,7 +174,7 @@ public class ExampleProxyTest extends FreeSpec {
 									}
 								});
 								intercept(UnsupportedOperationException.class,
-										"(?s).*public String list\\(List<String> x0\\).*",
+										"(?s).*public String list\\(List<String> list0\\).*",
 										() -> dep.list(new ArrayList<>()));
 							});
 
@@ -187,7 +187,7 @@ public class ExampleProxyTest extends FreeSpec {
 									}
 								});
 								intercept(UnsupportedOperationException.class,
-										"(?s).*public <T> T generics1\\(List<T> x0\\).*",
+										"(?s).*public <T> T generics1\\(List<T> list0\\).*",
 										() -> dep.generics1(new ArrayList<String>()));
 							});
 					test("case: <T, S> T generics2(List<S> ts)",
@@ -199,7 +199,7 @@ public class ExampleProxyTest extends FreeSpec {
 									}
 								});
 								intercept(UnsupportedOperationException.class,
-										"(?s).*public <T, S> T generics2\\(List<S> x0\\).*",
+										"(?s).*public <T, S> T generics2\\(List<S> list0\\).*",
 										() -> dep.generics2(new ArrayList<String>()));
 							});
 
@@ -212,7 +212,7 @@ public class ExampleProxyTest extends FreeSpec {
 									}
 								});
 								intercept(UnsupportedOperationException.class,
-										"(?s).*public <T, S> T generics3\\(Map<S, List<T>> x0\\).*",
+										"(?s).*public <T, S> T generics3\\(Map<S, List<T>> map0\\).*",
 										() -> {
 											dep.generics3(new LinkedHashMap<String, List<String>>());
 										});

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -22,7 +22,9 @@ public class ExampleProxyTest extends FreeSpec {
 		U baz(List<U> arg1);
 
 		String list(List<String> strings);
+
 		<T> T generic(T t);
+
 		<T> T generics1(List<T> ts);
 
 		<T, S> T generics2(List<S> ts);
@@ -123,16 +125,20 @@ public class ExampleProxyTest extends FreeSpec {
 					() -> dep.genericArg("1"));
 		});
 
-		test("A proxy handling generics works with proposed code templates",() -> {
+		test("A proxy handling generics works with proposed code templates", () -> {
 			final Dependency<String> proxy = TestProxy.proxy(Dependency.class, new Object() {
 				// ==> public <T> T generic(T x0){}
-				public <T> T generic(T x0){ return x0; }
+				public <T> T generic(T x0) {
+					return x0;
+				}
 
 				// ==> public U baz(List<U> x0){}
 				// works: public <X> X baz(List<X> x0){ return x0.get(0);}
 				// works: public String baz(List<String> x0){ return x0.get(0);}
-				// does not work public  int baz(List<Integer> x0){ return x0.get(0);}
-				public <X> X baz(List<X> x0){ return x0.get(0);}
+				// does not work public int baz(List<Integer> x0){ return x0.get(0);}
+				public <X> X baz(List<X> x0) {
+					return x0.get(0);
+				}
 
 			});
 			Expect.expectString(proxy.generic("abc")).isEqual("abc");
@@ -153,6 +159,13 @@ public class ExampleProxyTest extends FreeSpec {
 								final Dependency dep = TestProxy.proxy(Dependency.class);
 								intercept(UnsupportedOperationException.class,
 										"(?s).*public U baz\\(List<U> list0\\).*",
+										() -> dep.baz(new ArrayList()));
+							});
+					test("case: Object baz(List arg1)",
+							() -> {
+								final Dependency dep = TestProxy.proxy(Dependency.class);
+								intercept(UnsupportedOperationException.class,
+										"(?s).*public Object baz\\(List list0\\).*",
 										() -> dep.baz(new ArrayList()));
 							});
 					test("case: String list(List<String> strings)",


### PR DESCRIPTION
See comments for proposed (==>) code which works with with TestProxy 

```java
test("A proxy handling generics works with proposed code templates",() -> {
			final Dependency<String> proxy = TestProxy.proxy(Dependency.class, new Object() {
				// ==> public <T> T generic(T x0){}
				public <T> T generic(T x0){ return x0; }

				// ==> public U baz(List<U> x0){}
				// works: public <X> X baz(List<X> x0){ return x0.get(0);}
				// works: public String baz(List<String> x0){ return x0.get(0);}
				// does not work public  int baz(List<Integer> x0){ return x0.get(0);}
				public <X> X baz(List<X> x0){ return x0.get(0);}

			});
			Expect.expectString(proxy.generic("abc")).isEqual("abc");
			Expect.expectString(proxy.baz(Arrays.asList("abc"))).contains("abc");
		});
```