### PR TITLE
Better handling of array parameter naming in error message

### DIFF
--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -161,21 +161,17 @@ public class TestProxy {
 	private static String methodSignatureWithoutGenerics(final Method method) {
 		final Class<?>[] types = method.getParameterTypes();
 		final String argList;
-		if (types == null) {
-			argList = "";
-		} else {
-			final Map<String, Integer> count = new LinkedHashMap<>();
-			final List<String> args = map(types, t -> {
-				final String className = t.getSimpleName();
-				final String argName = decapitalize(className).replace("[]","");
-				Integer c = count.get(argName);
-				c = c == null ? 1 : c + 1;
-				count.put(argName, c);
-				return className + " " + argName + c;
-			});
-			argList = mkString(args, ", ");
-		}
-		final String methodName = method.getName();
+    final Map<String, Integer> count = new LinkedHashMap<>();
+    final List<String> args = map(types, t -> {
+      final String className = t.getSimpleName();
+      final String argName = decapitalize(className).replace("[]","");
+      Integer c = count.get(argName);
+      c = c == null ? 1 : c + 1;
+      count.put(argName, c);
+      return className + " " + argName + c;
+    });
+    argList = mkString(args, ", ");
+    final String methodName = method.getName();
 		final String returnTypeName = method.getReturnType().getSimpleName();
 
 		return "public " + returnTypeName + " " + methodName + "(" + argList + ")";

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -167,7 +167,7 @@ public class TestProxy {
 			final Map<String, Integer> count = new LinkedHashMap<>();
 			final List<String> args = map(types, t -> {
 				final String className = t.getSimpleName();
-				final String argName = decapitalize(className);
+				final String argName = decapitalize(className).replace("[]","");
 				Integer c = count.get(argName);
 				c = c == null ? 1 : c + 1;
 				count.put(argName, c);

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -205,7 +205,7 @@ public class TestProxy {
 		final Type[] parameterTypes = method.getGenericParameterTypes();
 		final Class<?>[] parameterClasses = method.getParameterTypes();
 
-		if (parameterTypes == null || parameterClasses == null) {
+		if (parameterTypes == null) {
 			return "";
 		}
 

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -223,7 +223,8 @@ public class TestProxy {
 			final boolean isErasedOrObject = Object.class.equals(clazz);
 
 			final String clazzSimpleName = clazz.getSimpleName();
-			final String argName = decapitalize(clazzSimpleName);
+			final String argName1 = decapitalize(clazzSimpleName).replaceAll("[^a-zA-Z0-1_]+", "");
+			final String argName = argName1.length() == 0 ? "x" : argName1;
 			final String className = isErasedOrObject ? "Object" : getTypeName(arg);
 
 			Integer c = count.get(argName);

--- a/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
+++ b/src/main/java/de/tobiasroeser/lambdatest/proxy/TestProxy.java
@@ -223,8 +223,7 @@ public class TestProxy {
 			final boolean isErasedOrObject = Object.class.equals(clazz);
 
 			final String clazzSimpleName = clazz.getSimpleName();
-			final String argName1 = decapitalize(clazzSimpleName).replaceAll("[^a-zA-Z0-1_]+", "");
-			final String argName = argName1.length() == 0 ? "x" : argName1;
+			final String argName = decapitalize(clazzSimpleName).replace("[]", "");
 			final String className = isErasedOrObject ? "Object" : getTypeName(arg);
 
 			Integer c = count.get(argName);

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -204,7 +204,7 @@ public class ExampleProxyTest extends FreeSpec {
 							() -> {
 								final Dependency dep = TestProxy.proxy(Dependency.class);
 								intercept(UnsupportedOperationException.class,
-										"(?s).*\\Qpublic void xarrayParam(String[] string1)\\E.*",
+										"(?s).*\\Qpublic void arrayParam(String[] string1)\\E.*",
 										() -> dep.arrayParam(new String[0]));
 							});
 				});

--- a/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
+++ b/src/test/java/de/tobiasroeser/lambdatest/proxy/ExampleProxyTest.java
@@ -30,6 +30,8 @@ public class ExampleProxyTest extends FreeSpec {
 		<T, S> T generics2(List<S> ts);
 
 		<T, S> T generics3(Map<S, List<T>> ts);
+
+		void arrayParam(String[] strings);
 	}
 
 	class ServiceWithDependency {
@@ -197,6 +199,13 @@ public class ExampleProxyTest extends FreeSpec {
 								intercept(UnsupportedOperationException.class,
 										"(?s).*\\Qpublic <T, S> T generics3(Map<S, List<T>> map1)\\E.*",
 										() -> dep.generics3(new LinkedHashMap<String, List<String>>()));
+							});
+					test("case: void arrayParam(String[] string1)",
+							() -> {
+								final Dependency dep = TestProxy.proxy(Dependency.class);
+								intercept(UnsupportedOperationException.class,
+										"(?s).*\\Qpublic void xarrayParam(String[] string1)\\E.*",
+										() -> dep.arrayParam(new String[0]));
 							});
 				});
 	}


### PR DESCRIPTION
Current error message for array params is not correct:
To handle this call in the proxy delegate object, add a method with the following signature:
   ==>  public String abc(Month[] month[]1) { ... }  
it should be 
  ==> public String abc(Month[] month1) { ... }

This patch fixes this.